### PR TITLE
Add a ctor for IpPrefix to accept ip structure and mask

### DIFF
--- a/common/ipprefix.cpp
+++ b/common/ipprefix.cpp
@@ -53,6 +53,14 @@ IpPrefix::IpPrefix(uint32_t ipPrefix, int mask) : m_ip(ipPrefix), m_mask(mask)
     }
 }
 
+IpPrefix::IpPrefix(const ip_addr_t &ip, int mask) : m_ip(ip), m_mask(mask)
+{
+    if (!isValid())
+    {
+        throw std::invalid_argument("Invalid IpPrefix from ip structure and mask");
+    }
+}
+
 bool IpPrefix::isValid()
 {
     if (m_mask < 0) return false;

--- a/common/ipprefix.h
+++ b/common/ipprefix.h
@@ -14,6 +14,7 @@ public:
     IpPrefix() = default;
     IpPrefix(const std::string &ipPrefixStr);
     IpPrefix(uint32_t addr, int mask);
+    IpPrefix(const ip_addr_t &ip, int mask);
 
     inline bool isV4() const
     {


### PR DESCRIPTION
Why I did this?

Need to construct a IpPrefix instance from ip structure and mask length.

